### PR TITLE
Fix a race condition after closing a dialog 

### DIFF
--- a/src/opensak/gui/dialogs/update_location_dialog.py
+++ b/src/opensak/gui/dialogs/update_location_dialog.py
@@ -387,10 +387,22 @@ class UpdateLocationDialog(QDialog):
         self._log.clear()
         self._progress_label.setText(tr("update_loc_running", total=len(rows)))
 
-        self._worker = ReverseGeocodeWorker(rows)
+        self._worker = ReverseGeocodeWorker(rows, parent=self)
         self._worker.row_done.connect(self._on_row_done)
         self._worker.all_done.connect(self._on_done)
         self._worker.cancelled.connect(self._on_cancelled)
+        # Forget the worker on QThread.finished (emitted after run() has
+        # returned and isRunning() is already false) — NOT from the slots
+        # driven by all_done/cancelled, which are emitted from inside run()
+        # while the thread is still alive. Dropping the last reference there
+        # left run()'s own stack frame holding it, so the QThread was
+        # destroyed from inside its own run() and Qt aborted the process
+        # ("QThread: Destroyed while thread '' is still running"). Same rule
+        # as ImportWorker in import_dialog.py. parent=self additionally keeps
+        # the C++ object owned by the dialog, so Python refcounting can never
+        # delete a running thread on its own. _on_worker_finished is connected
+        # before deleteLater so it runs first; both are queued.
+        self._worker.finished.connect(self._on_worker_finished)
         self._worker.finished.connect(self._worker.deleteLater)
         self._worker.start()
 
@@ -437,8 +449,12 @@ class UpdateLocationDialog(QDialog):
         self._set_controls_enabled(True)
         if not self._from_context_menu:
             self._rb_this.setEnabled(False)
-        # The worker is about to delete itself (finished.connect(deleteLater));
-        # drop our reference now so closeEvent never touches a dangling C++ object.
+
+    def _on_worker_finished(self) -> None:
+        """run() has returned and the thread has stopped — only now is it safe
+        to drop our reference. The worker deletes itself via deleteLater
+        (connected after this slot), so closeEvent never sees a dangling
+        C++ object either."""
         self._worker = None
 
     def closeEvent(self, event) -> None:

--- a/tests/unit-tests/test_update_location_dialog.py
+++ b/tests/unit-tests/test_update_location_dialog.py
@@ -379,7 +379,7 @@ class TestUpdateLocationDialog:
         started = []
 
         class FakeWorker:
-            def __init__(self, rows):
+            def __init__(self, rows, parent=None):
                 self.row_done = MagicMock()
                 self.all_done = MagicMock()
                 self.cancelled = MagicMock()
@@ -458,7 +458,7 @@ class TestUpdateLocationDialog:
         connected = []
 
         class FakeWorker:
-            def __init__(self, rows):
+            def __init__(self, rows, parent=None):
                 self.row_done = MagicMock()
                 self.all_done = MagicMock()
                 self.cancelled = MagicMock()
@@ -474,9 +474,30 @@ class TestUpdateLocationDialog:
                 pass
 
         fake = FakeWorker([])
-        monkeypatch.setattr(uld, "ReverseGeocodeWorker", lambda rows: fake)
+        monkeypatch.setattr(
+            uld, "ReverseGeocodeWorker", lambda rows, parent=None: fake
+        )
         dlg._start()
         fake.finished.connect.assert_any_call(fake.deleteLater)
+        # The reference must be dropped from a finished-slot, never from
+        # all_done/cancelled (which fire while run() is still on the stack).
+        fake.finished.connect.assert_any_call(dlg._on_worker_finished)
+
+    def test_worker_reference_survives_all_done_and_drops_on_finished(
+        self, qtbot, db
+    ):
+        # Regression: _finalize() used to clear _worker while run() was still
+        # executing, leaving run()'s own stack frame as the last reference —
+        # the QThread was then destroyed from inside its own thread, which Qt
+        # aborts on ("QThread: Destroyed while thread is still running").
+        dlg = UpdateLocationDialog(gc_codes=["GC1"])
+        qtbot.addWidget(dlg)
+        worker = MagicMock()
+        dlg._worker = worker
+        dlg._on_done(UpdateLocationResult(updated=1))
+        assert dlg._worker is worker
+        dlg._on_worker_finished()
+        assert dlg._worker is None
 
     def test_menu_mode_finalize_redisables_this(self, qtbot, db):
         dlg = UpdateLocationDialog()


### PR DESCRIPTION
The worker is created with parent=self, so the dialog owns the C++ object and Python refcounting alone can never destroy a running thread.
self._worker = None moved out of _finalize() (driven by all_done, fires while the thread is alive) into a new _on_worker_finished() slot connected to QThread.finished, which only fires after run() has returned and isRunning() is already false. It's connected before deleteLater so it runs first.

related to https://github.com/OpenSAK-Org/OpenSAK/issues/800